### PR TITLE
Make appName and key always lowercase to match how subdomains are always lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript": "^2.7.2"
   },
   "jest": {
+    "testURL": "http://localhost",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -2,6 +2,6 @@ import { sanitizeName } from './helpers'
 
 describe('sanitizeName', () => {
   it('normalizes a string', () => {
-    expect(sanitizeName('myAppName/../@!foo')).toBe('myAppName------foo')
+    expect(sanitizeName('myAppName/../@!foo')).toBe('myappname------foo')
   })
 })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,1 +1,1 @@
-export const sanitizeName = (appOrKey: string): string => appOrKey.replace(/\W/g, '-')
+export const sanitizeName = (appOrKey: string): string => appOrKey.replace(/\W/g, '-').toLowerCase()

--- a/src/package-resolvers/subdomain/index.test.ts
+++ b/src/package-resolvers/subdomain/index.test.ts
@@ -5,8 +5,8 @@ describe('subdomain package resolver', () => {
   describe('getPackageIdentifierFromRequest', () => {
     it('gets the app and key from subdomains', () => {
       const req = httpMocks.createRequest()
-      req.hostname = 'someKey.myApp.backstage.example.com'
-      const expected = { app: 'myApp', key: 'someKey' }
+      req.hostname = 'somekey.myapp.backstage.example.com'
+      const expected = { app: 'myapp', key: 'somekey' }
 
       expect(subdomain.getPackageIdentifierFromRequest(req)).toEqual(expected)
     })
@@ -17,10 +17,10 @@ describe('subdomain package resolver', () => {
       const req = httpMocks.createRequest()
       req.protocol = 'https'
       req.get = jest.fn(() => 'backstage.example.com')
-      const packageIdentifier = { app: 'myApp', key: 'someKey' }
+      const packageIdentifier = { app: 'myapp', key: 'somekey' }
 
       expect(subdomain.getPackageURL(req, packageIdentifier))
-        .toBe('https://someKey.myApp.backstage.example.com/')
+        .toBe('https://somekey.myapp.backstage.example.com/')
     })
   })
 })

--- a/src/storage-backends/file-system/post-file.spec.ts
+++ b/src/storage-backends/file-system/post-file.spec.ts
@@ -70,7 +70,7 @@ describe('postFile', () => {
     const res = httpMocks.createResponse()
     handler(req, res, jest.fn())
 
-    expect(mockFS.mkdirSync).toHaveBeenCalledWith(`${rootDir}/packages/myApp`)
+    expect(mockFS.mkdirSync).toHaveBeenCalledWith(`${rootDir}/packages/myapp`)
   })
 
   it('deletes an existing directory for the key if it already exists', () => {
@@ -79,7 +79,7 @@ describe('postFile', () => {
     const res = httpMocks.createResponse()
     handler(req, res, jest.fn())
 
-    expect(mockRimRaf.sync).toHaveBeenCalledWith(`${rootDir}/packages/myApp/someKey`)
+    expect(mockRimRaf.sync).toHaveBeenCalledWith(`${rootDir}/packages/myapp/somekey`)
   })
 
   it('creates a directory for the key', () => {
@@ -87,7 +87,7 @@ describe('postFile', () => {
     const res = httpMocks.createResponse()
     handler(req, res, jest.fn())
 
-    expect(mockFS.mkdirSync).toHaveBeenCalledWith(`${rootDir}/packages/myApp/someKey`)
+    expect(mockFS.mkdirSync).toHaveBeenCalledWith(`${rootDir}/packages/myapp/somekey`)
   })
 
   it('extracts the archive to `<rootDir>/packages/<appName>/<keyName>`', () => {
@@ -95,7 +95,7 @@ describe('postFile', () => {
     const res = httpMocks.createResponse()
     handler(req, res, jest.fn())
 
-    const extractionPath = '/var/www/files/packages/myApp/someKey'
+    const extractionPath = '/var/www/files/packages/myapp/somekey'
     expect(mockTar.extract).toHaveBeenCalledWith({ file: req.file.path, cwd: extractionPath })
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,19 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "es2015"
+    ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "dist",                        /* Redirect output structure to the directory. */
-    "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "outDir": "dist" /* Redirect output structure to the directory. */,
+    "rootDir": "src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
@@ -27,8 +29,8 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true,                /* Report errors on unused locals. */
-    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
@@ -40,7 +42,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": false                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": false /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -53,9 +55,5 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "exclude": [
-    "**/*.spec.ts",
-    "dist",
-    "node_modules"
-  ]
+  "exclude": ["**/*.spec.ts", "dist", "node_modules"]
 }


### PR DESCRIPTION
I ran into this issue when I was trying to dockerize this. Here's what happened:

Our branch names generally contain a jira issue id which contains capital letters. Something like: `NHCRES-123`. 

If I use the subdomain package resolver this would result in a url like `http://NHCRES-123.myapp.backstage-server.com`, which most browsers change to `http://nhcres-123.myapp.backstage-server.com`. If this server is running on a case sensitive file system then package is not found. 

IMO it is a nicer default to always convert package name (key) and app name to lowercase to solve this issue. 